### PR TITLE
Fix build with Flutter 2 and Null Safety

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -82,7 +82,7 @@ packages:
       name: flutter_keyboard_visibility
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "5.0.1"
   flutter_keyboard_visibility_platform_interface:
     dependency: transitive
     description:
@@ -113,7 +113,7 @@ packages:
       name: font_awesome_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.11.0"
+    version: "9.0.0"
   highlight:
     dependency: transitive
     description:
@@ -174,7 +174,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -209,7 +209,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:
@@ -223,7 +223,7 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.2"
+    version: "6.0.3"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -244,7 +244,7 @@ packages:
       name: url_launcher_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   url_launcher_web:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,8 +10,8 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.2
-  font_awesome_flutter: ^8.11.0
-  url_launcher: ^6.0.2
+  font_awesome_flutter: ^9.0.0
+  url_launcher: ^6.0.3
   
 dev_dependencies:
   flutter_test:

--- a/lib/src/code_controller.dart
+++ b/lib/src/code_controller.dart
@@ -207,7 +207,8 @@ class CodeController extends TextEditingController {
   }
 
   @override
-  TextSpan buildTextSpan({TextStyle? style, bool? withComposing}) {
+  TextSpan buildTextSpan(
+      {required BuildContext context, TextStyle? style, bool? withComposing}) {
     // Retrieve pattern regexp
     final patternList = <String>[];
     if (_webSpaceFix) {

--- a/lib/src/code_field.dart
+++ b/lib/src/code_field.dart
@@ -14,7 +14,8 @@ class LineNumberController extends TextEditingController {
   LineNumberController(this.lineNumberBuilder);
 
   @override
-  TextSpan buildTextSpan({TextStyle? style, bool? withComposing}) {
+  TextSpan buildTextSpan(
+      {required BuildContext context, TextStyle? style, bool? withComposing}) {
     final children = <TextSpan>[];
     final list = text.split("\n");
     for (int k = 0; k < list.length; k++) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -68,7 +68,7 @@ packages:
       name: flutter_keyboard_visibility
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "5.0.1"
   flutter_keyboard_visibility_platform_interface:
     dependency: transitive
     description:
@@ -153,7 +153,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -188,7 +188,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   linked_scroll_controller: ^0.2.0-nullsafety.0
   highlight: ^0.7.0
   flutter_highlight: ^0.7.0
-  flutter_keyboard_visibility: ^5.0.0
+  flutter_keyboard_visibility: ^5.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
I'm using dev channel 2.2.0-10.1.pre, however it looks like the missing breaking change came in Flutter 2.0:
https://flutter.dev/docs/release/breaking-changes/buildtextspan-buildcontext

Also used pub upgrade to update both top-level and example pubspec.yamls to latest versions.  Specifically the Dart compiler was crashing with a (internal) exception regarding null safety, possibly due to font_awesome_flutter not being null safe.

The project was clearly already migrated to null safety, so it's possible it just hasn't been used in that context despite being migrated?