### PR TITLE
Update to latest TextEditingController.onKey API

### DIFF
--- a/lib/src/code_controller.dart
+++ b/lib/src/code_controller.dart
@@ -83,12 +83,12 @@ class CodeController extends TextEditingController {
     );
   }
 
-  bool onKey(RawKeyEvent event) {
+  KeyEventResult onKey(RawKeyEvent event) {
     if (event.isKeyPressed(LogicalKeyboardKey.tab)) {
       text = text.replaceRange(selection.start, selection.end, "\t");
-      return true;
+      return KeyEventResult.handled;
     }
-    return false;
+    return KeyEventResult.ignored;
   }
 
   /// Method to get untransformed text

--- a/lib/src/code_field.dart
+++ b/lib/src/code_field.dart
@@ -133,7 +133,7 @@ class CodeFieldState extends State<CodeField> {
     _onTextChanged();
   }
 
-  bool _onKey(FocusNode node, RawKeyEvent event) {
+  KeyEventResult _onKey(FocusNode node, RawKeyEvent event) {
     return widget.controller.onKey(event);
   }
 


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/67359

moved this API from a bool to dynamic (in preparation to move to KeyEventResult).

Without this change, code_text_field crashes when run under null safety.

Please confirm that I inferred the right return values for this use of the API?  Thanks!