### PR TITLE
added readOnly flag

### DIFF
--- a/lib/src/code_field.dart
+++ b/lib/src/code_field.dart
@@ -86,6 +86,9 @@ class CodeField extends StatefulWidget {
   /// {@macro flutter.widgets.textField.enabled}
   final bool? enabled;
 
+  /// {@macro flutter.widgets.editableText.readOnly}
+  final bool readOnly;
+
   final Color? background;
   final EdgeInsets padding;
   final Decoration? decoration;
@@ -105,6 +108,7 @@ class CodeField extends StatefulWidget {
     this.padding = const EdgeInsets.symmetric(),
     this.lineNumberStyle = const LineNumberStyle(),
     this.enabled,
+    this.readOnly = false,
     this.cursorColor,
     this.textSelectionTheme,
     this.lineNumberBuilder,
@@ -282,6 +286,7 @@ class CodeFieldState extends State<CodeField> {
       autocorrect: false,
       enableSuggestions: false,
       enabled: widget.enabled,
+      readOnly: widget.readOnly,
     );
 
     final codeCol = Theme(


### PR DESCRIPTION
When you use `enabled: false`, it disables focus and text selection so you cannot copy text from there.
Using `readOnly: true` keeps this functionality.