### PR TITLE
fix typo in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ dependencies:
 In your library add the following import:
 
 ```dart
-import 'package:code_text_field/code_field.dart';
+import 'package:code_text_field/code_text_field.dart';
 ```
 
 


### PR DESCRIPTION
`import 'package:code_text_field/code_field.dart';` should be `import 'package:code_text_field/code_text_field.dart';`

( encounter this error when copy the example from flutter pub 👀

<img width="979" alt="截圖 2022-12-22 下午11 50 01" src="https://user-images.githubusercontent.com/68415893/209171818-a112c4ef-9457-4ddb-8445-503f5b6772b6.png">

BTW thanks for contributing this wonderful package !
( It helps me a lot when building final project for window programming design course 💯
