### PR TITLE
feat: add automatic completion.

### DIFF
--- a/lib/code_text_field.dart
+++ b/lib/code_text_field.dart
@@ -1,3 +1,4 @@
+export 'src/code_field/code_auto_complete.dart';
 export 'src/code_field/code_controller.dart';
 export 'src/code_field/code_field.dart';
 export 'src/code_field/editor_params.dart';

--- a/lib/src/code_field/code_auto_complete.dart
+++ b/lib/src/code_field/code_auto_complete.dart
@@ -7,7 +7,7 @@ import '../../code_text_field.dart';
 /// config auto complete
 class CodeAutoComplete<T> {
   /// can input your options which created through editor text and language.
-  List<T> Function(String, Mode?) optionsBuilder;
+  List<T> Function(String, int cursorIndex, Mode?) optionsBuilder;
 
   /// depends on your options, you can create your own item widget.
   final Widget Function(BuildContext, T, bool, Function(String) onTap)
@@ -75,6 +75,7 @@ class CodeAutoComplete<T> {
           current = 0;
           options = optionsBuilder(
             widget.controller.text,
+            widget.controller.selection.baseOffset,
             widget.controller.language,
           );
           if (!focusNode.hasFocus || options.isEmpty) return const Offstage();

--- a/lib/src/code_field/code_auto_complete.dart
+++ b/lib/src/code_field/code_auto_complete.dart
@@ -1,0 +1,204 @@
+import 'dart:async';
+import 'dart:math';
+import 'package:flutter/material.dart';
+import 'package:highlight/highlight.dart';
+import '../../code_text_field.dart';
+
+/// config auto complete
+class CodeAutoComplete<T> {
+  /// can input your options which created through editor text and language.
+  List<T> Function(String, Mode?) optionsBuilder;
+
+  /// depends on your options, you can create your own item widget.
+  final Widget Function(BuildContext, T, bool, Function(String) onTap)
+      itemBuilder;
+
+  /// set the tip panel size.
+  final BoxConstraints constraints;
+
+  /// set the tip panel background color.
+  final Color? backgroundColor;
+
+  /// the tip panel display status.
+  bool isShowing = false;
+
+  /// the tip panel current index of items.
+  int current = 0;
+
+  /// the tip panel set state function.
+  void Function(void Function())? panelSetState;
+
+  /// the code field widget.
+  late CodeField widget;
+
+  /// a getter function to get the text value from option<T>, default to toString
+  String Function(T)? optionValue;
+
+  /// the options list.
+  List<T> options = [];
+
+  /// the panel offset.
+  Offset? offset;
+  final StreamController streamController = StreamController.broadcast();
+  Stream get stream => streamController.stream;
+
+  CodeAutoComplete({
+    required this.optionsBuilder,
+    required this.itemBuilder,
+    this.offset,
+    this.constraints = const BoxConstraints(maxHeight: 300, maxWidth: 240),
+    this.backgroundColor,
+    this.optionValue,
+  });
+
+  OverlayEntry? panelOverlay;
+
+  /// remove the tip panel.
+  void remove() {
+    if (panelOverlay != null) panelOverlay?.remove();
+    panelOverlay = null;
+  }
+
+  /// hide the tip panel.
+  void hide() {
+    streamController.add(null);
+  }
+
+  /// create and show the tip panel.
+  void show(BuildContext codeFieldContext, CodeField wdg, FocusNode focusNode) {
+    widget = wdg;
+    OverlayEntry overlayEntry = OverlayEntry(builder: (context) {
+      return StreamBuilder(
+        stream: stream,
+        builder: (context, snapshot) {
+          isShowing = false;
+          current = 0;
+          options = optionsBuilder(
+            widget.controller.text,
+            widget.controller.language,
+          );
+          if (!focusNode.hasFocus || options.isEmpty) return const Offstage();
+          if (snapshot.hasData &&
+              snapshot.data != true &&
+              snapshot.data != null &&
+              '${snapshot.data}'.isNotEmpty) {
+            isShowing = true;
+            return panelWrap(codeFieldContext, wdg, focusNode);
+          } else {
+            return const Offstage();
+          }
+        },
+      );
+    });
+
+    panelOverlay = overlayEntry;
+    Overlay.of(codeFieldContext).insert(overlayEntry);
+  }
+
+  /// the core widget of tip panel.
+  Widget buildPanel(BuildContext context) {
+    return SingleChildScrollView(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: options
+            .map((tip) => itemBuilder(
+                context, tip, current == options.indexOf(tip), write))
+            .toList(),
+      ),
+    );
+  }
+
+  /// write the text to code field.
+  void write(String text) {
+    var offset = widget.controller.selection.baseOffset;
+    int start = repeatCount(widget.controller.text.substring(0, offset), text);
+    widget.controller
+      ..text = widget.controller.text.replaceRange(
+          widget.controller.selection.baseOffset - start,
+          widget.controller.selection.baseOffset,
+          text)
+      ..selection = TextSelection.fromPosition(
+          TextPosition(offset: offset + text.length - start));
+    widget.onChanged?.call(widget.controller.text);
+    hide();
+  }
+
+  /// write the current item text to code field.
+  void writeCurrent() {
+    if (options.isNotEmpty) {
+      write(optionValue?.call(options[current]) ?? options[current].toString());
+    }
+  }
+
+  /// get the repeat count of pre word and tip word.
+  static int repeatCount(String text, String text2) {
+    text = text.toLowerCase();
+    text2 = text2.toLowerCase();
+    var same = 0;
+    while (text2.isNotEmpty) {
+      if (text.endsWith(text2)) {
+        return same += text2.length;
+      }
+      text2 = text2.substring(0, text2.length - 1);
+    }
+    return same;
+  }
+
+  /// get the panel offset through the cursor offset.
+  Offset cursorOffset(
+      BuildContext context, CodeField widget, FocusNode focusNode) {
+    var s = widget.controller.text;
+    TextStyle textStyle = widget.textStyle ?? const TextStyle();
+    textStyle = textStyle.copyWith(
+      fontSize: textStyle.fontSize ?? 16.0,
+    );
+    TextPainter painter = TextPainter(
+      textDirection: TextDirection.ltr,
+      text: TextSpan(
+        style: textStyle,
+        text: s.substring(0, widget.controller.selection.baseOffset),
+      ),
+    )..layout();
+    var cursorBefore = s.substring(0, widget.controller.selection.baseOffset);
+    TextPainter hpainter = TextPainter(
+      textDirection: TextDirection.ltr,
+      text: TextSpan(
+        style: textStyle,
+        text: cursorBefore.substring(max(cursorBefore.lastIndexOf('\n'), 0)),
+      ),
+    )..layout();
+
+    return Offset(focusNode.offset.dx + hpainter.width,
+            focusNode.offset.dy + painter.height) +
+        (offset ?? Offset.zero);
+  }
+
+  /// the style widget of tip panel.
+  Widget panelWrap(BuildContext context, CodeField wdg, FocusNode focusNode) {
+    Offset offset = cursorOffset(context, widget, focusNode);
+    return Positioned(
+        top: offset.dy,
+        left: offset.dx,
+        child: Material(
+          elevation: 8,
+          child: StatefulBuilder(builder: (context, setState) {
+            panelSetState = setState;
+            return background(ConstrainedBox(
+              constraints: constraints,
+              child: ConstrainedBox(
+                constraints: constraints,
+                child: buildPanel(context),
+              ),
+            ));
+          }),
+        ));
+  }
+
+  /// the style widget of tip panel.
+  Widget background(Widget content) {
+    if (backgroundColor != null) {
+      return ColoredBox(color: backgroundColor!, child: content);
+    }
+    return content;
+  }
+}

--- a/lib/src/code_field/code_controller.dart
+++ b/lib/src/code_field/code_controller.dart
@@ -8,10 +8,12 @@ import '../code_modifiers/indent_code_modifier.dart';
 import '../code_modifiers/tab_code_modifier.dart';
 import '../code_theme/code_theme.dart';
 import '../code_theme/code_theme_data.dart';
+import 'code_auto_complete.dart';
 import 'editor_params.dart';
 
 class CodeController extends TextEditingController {
   Mode? _language;
+  CodeAutoComplete? autoComplete;
 
   /// A highlight language to parse the text with
   Mode? get language => _language;
@@ -142,6 +144,29 @@ class CodeController extends TextEditingController {
     if (event.isKeyPressed(LogicalKeyboardKey.tab)) {
       text = text.replaceRange(selection.start, selection.end, '\t');
       return KeyEventResult.handled;
+    }
+
+    if (autoComplete?.isShowing ?? false) {
+      if (event.isKeyPressed(LogicalKeyboardKey.arrowDown)) {
+        autoComplete!.current =
+            (autoComplete!.current + 1) % autoComplete!.options.length;
+        autoComplete!.panelSetState?.call(() {});
+        return KeyEventResult.handled;
+      }
+      if (event.isKeyPressed(LogicalKeyboardKey.arrowUp)) {
+        autoComplete!.current =
+            (autoComplete!.current - 1) % autoComplete!.options.length;
+        autoComplete!.panelSetState?.call(() {});
+        return KeyEventResult.handled;
+      }
+      if (event.isKeyPressed(LogicalKeyboardKey.enter)) {
+        autoComplete!.writeCurrent();
+        return KeyEventResult.handled;
+      }
+      if (event.isKeyPressed(LogicalKeyboardKey.escape)) {
+        autoComplete!.hide();
+        return KeyEventResult.handled;
+      }
     }
 
     return KeyEventResult.ignored;

--- a/lib/src/code_field/code_field.dart
+++ b/lib/src/code_field/code_field.dart
@@ -329,7 +329,7 @@ class _CodeFieldState extends State<CodeField> {
         hintStyle: widget.hintStyle,
       ),
       onTapOutside: (e) {
-        hideAutoComplete();
+        Future.delayed(const Duration(milliseconds: 300), hideAutoComplete);
       },
       cursorColor: cursorColor,
       autocorrect: false,

--- a/lib/src/code_field/code_field.dart
+++ b/lib/src/code_field/code_field.dart
@@ -7,6 +7,7 @@ import 'package:linked_scroll_controller/linked_scroll_controller.dart';
 import '../code_theme/code_theme.dart';
 import '../line_numbers/line_number_controller.dart';
 import '../line_numbers/line_number_style.dart';
+import 'code_auto_complete.dart';
 import 'code_controller.dart';
 
 class CodeField extends StatefulWidget {
@@ -68,6 +69,7 @@ class CodeField extends StatefulWidget {
   final bool horizontalScroll;
   final String? hintText;
   final TextStyle? hintStyle;
+  final CodeAutoComplete? autoComplete;
 
   const CodeField({
     Key? key,
@@ -97,6 +99,7 @@ class CodeField extends StatefulWidget {
     this.selectionControls,
     this.hintText,
     this.hintStyle,
+    this.autoComplete,
   }) : super(key: key);
 
   @override
@@ -127,7 +130,17 @@ class _CodeFieldState extends State<CodeField> {
     _focusNode!.onKey = _onKey;
     _focusNode!.attach(context, onKey: _onKey);
 
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      createAutoComplate();
+    });
+
     _onTextChanged();
+  }
+
+  void createAutoComplate() {
+    widget.autoComplete?.show(context, widget, _focusNode!);
+    widget.controller.autoComplete = widget.autoComplete;
+    _codeScroll?.addListener(hideAutoComplete);
   }
 
   KeyEventResult _onKey(FocusNode node, RawKeyEvent event) {
@@ -145,6 +158,7 @@ class _CodeFieldState extends State<CodeField> {
     _codeScroll?.dispose();
     _numberController?.dispose();
     _keyboardVisibilitySubscription?.cancel();
+    widget.autoComplete?.remove();
     super.dispose();
   }
 
@@ -211,6 +225,14 @@ class _CodeFieldState extends State<CodeField> {
           widget.horizontalScroll ? null : const NeverScrollableScrollPhysics(),
       child: intrinsic,
     );
+  }
+
+  void removeAutoComplete() {
+    widget.autoComplete?.remove();
+  }
+
+  void hideAutoComplete() {
+    widget.autoComplete?.hide();
   }
 
   @override
@@ -286,7 +308,10 @@ class _CodeFieldState extends State<CodeField> {
       keyboardType: widget.keyboardType,
       smartQuotesType: widget.smartQuotesType,
       focusNode: _focusNode,
-      onTap: widget.onTap,
+      onTap: () {
+        widget.autoComplete?.hide();
+        widget.onTap?.call();
+      },
       scrollPadding: widget.padding,
       style: textStyle,
       controller: widget.controller,
@@ -303,11 +328,17 @@ class _CodeFieldState extends State<CodeField> {
         hintText: widget.hintText,
         hintStyle: widget.hintStyle,
       ),
+      onTapOutside: (e) {
+        hideAutoComplete();
+      },
       cursorColor: cursorColor,
       autocorrect: false,
       enableSuggestions: false,
       enabled: widget.enabled,
-      onChanged: widget.onChanged,
+      onChanged: (text) {
+        widget.onChanged?.call(text);
+        widget.autoComplete?.streamController.add(text);
+      },
       readOnly: widget.readOnly,
     );
 

--- a/test/code_auto_complete_test.dart
+++ b/test/code_auto_complete_test.dart
@@ -1,0 +1,9 @@
+import 'package:code_text_field/code_text_field.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('test write back pre function.', () {
+    var c = CodeAutoComplete.repeatCount('MA', 'MATCH');
+    expect(c, 2);
+  });
+}


### PR DESCRIPTION
Make customizing your own automatic completion possible.

For example: 
```dart
CodeField(
  ..., 
  autoComplete: CodeAutoComplete<String>(
    optionsBuilder: (text, cursorIndex, mode) {
      return ['class', 'import', 'abstract', 'with']; // anything your can create by text and mode.
    },
    itemBuilder: (context, tip, selected, onTap) {
      return ListTile(
        title: Text(tip),
        selected: selected, // you can use arrowDown、arrowUp、enter in code field and choose the tip.
        onTap: () {
          onTap(tip); // write back to the code field when you pick the item.
        },
      );
    },
    backgroundColor: Colors.black,
    offset: const Offset(0, 0),
  ),
),
```