### PR TITLE
Temporary fix for iOS horizontal scroll

### DIFF
--- a/lib/src/code_field/code_field.dart
+++ b/lib/src/code_field/code_field.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:math';
 
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:linked_scroll_controller/linked_scroll_controller.dart';
 
@@ -225,17 +228,21 @@ class _CodeFieldState extends State<CodeField> {
       ),
     );
 
-    return SingleChildScrollView(
-      padding: EdgeInsets.only(
-        left: leftPad,
-        right: widget.padding.right,
+    return MediaQuery(
+      // TODO: Temporary fix: https://github.com/flutter/flutter/issues/127017
+      data: !kIsWeb && Platform.isIOS
+          ? const MediaQueryData(
+              gestureSettings: DeviceGestureSettings(touchSlop: 8),
+            )
+          : MediaQuery.of(context),
+      child: SingleChildScrollView(
+        padding: EdgeInsets.only(
+          left: leftPad,
+          right: widget.padding.right,
+        ),
+        scrollDirection: Axis.horizontal,
+        child: intrinsic,
       ),
-      scrollDirection: Axis.horizontal,
-
-      /// Prevents the horizontal scroll if horizontalScroll is false
-      physics:
-          widget.horizontalScroll ? null : const NeverScrollableScrollPhysics(),
-      child: intrinsic,
     );
   }
 


### PR DESCRIPTION
It appears that recent updates in Flutter have resulted in a malfunction of horizontal code scrolling on iOS. I've successfully applied a temporary solution to address this problem, and you can find the details in the following GitHub issue: https://github.com/flutter/flutter/issues/127017

The current issue manifests as the inability to perform horizontal scrolling:

https://github.com/BertrandBev/code_field/assets/25605091/7e630657-1344-4992-bba2-1a7b766512b3

After implementing the temporary fix, the desired behavior is restored:

https://github.com/BertrandBev/code_field/assets/25605091/e25fdddc-bf17-4084-9c15-661c3af953f3

