### PR TITLE
Add gap between line numbers when word wrap is on

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -99,7 +99,6 @@ class _HomePageState extends State<HomePage> {
           TextButton.icon(
             style: TextButton.styleFrom(
               padding: EdgeInsets.symmetric(horizontal: 8.0),
-              primary: Colors.white,
             ),
             icon: Icon(FontAwesomeIcons.github),
             onPressed: () =>

--- a/lib/src/code_field/code_controller.dart
+++ b/lib/src/code_field/code_controller.dart
@@ -86,7 +86,8 @@ class CodeController extends TextEditingController {
       patternList.addAll(patternMap!.keys.map((e) => '($e)'));
       _styleList.addAll(patternMap!.values);
     }
-    _styleRegExp = RegExp(patternList.join('|'), multiLine: true, unicode: true);
+    _styleRegExp =
+        RegExp(patternList.join('|'), multiLine: true, unicode: true);
   }
 
   /// Sets a specific cursor position in the text
@@ -305,24 +306,18 @@ class CodeController extends TextEditingController {
   }
 
   CodeController copyWith({
-    Mode? _language,
-    CodeAutoComplete? autoComplete,
+    Mode? language,
     Map<String, TextStyle>? patternMap,
     Map<String, TextStyle>? stringMap,
     EditorParams? params,
     List<CodeModifier>? modifiers,
-    String? _languageId,
-    RegExp? _styleRegExp,
   }) {
     return CodeController(
-      _language: _language ?? this._language,
-      autoComplete: autoComplete ?? this.autoComplete,
+      language: language ?? this.language,
       patternMap: patternMap ?? this.patternMap,
       stringMap: stringMap ?? this.stringMap,
       params: params ?? this.params,
       modifiers: modifiers ?? this.modifiers,
-      _languageId: _languageId ?? this._languageId,
-      _styleRegExp: _styleRegExp ?? this._styleRegExp,
     );
   }
 }

--- a/lib/src/code_field/code_field.dart
+++ b/lib/src/code_field/code_field.dart
@@ -57,7 +57,7 @@ class CodeField extends StatefulWidget {
 
   /// {@macro flutter.widgets.textField.selectionControls}
   final TextSelectionControls? selectionControls;
-
+  final Key? fieldKey;
   final Color? background;
   final EdgeInsets padding;
   final Decoration? decoration;
@@ -70,7 +70,7 @@ class CodeField extends StatefulWidget {
   final TextStyle? hintStyle;
 
   const CodeField({
-    Key? key,
+    this.fieldKey,
     required this.controller,
     this.minLines,
     this.maxLines,
@@ -97,7 +97,7 @@ class CodeField extends StatefulWidget {
     this.selectionControls,
     this.hintText,
     this.hintStyle,
-  }) : super(key: key);
+  });
 
   @override
   State<CodeField> createState() => _CodeFieldState();
@@ -282,7 +282,7 @@ class _CodeFieldState extends State<CodeField> {
       );
     }
 
-    final codeField = TextField(
+    final codeField = TextField(key: widget.fieldKey,
       keyboardType: widget.keyboardType,
       smartQuotesType: widget.smartQuotesType,
       focusNode: _focusNode,

--- a/lib/src/code_field/code_field.dart
+++ b/lib/src/code_field/code_field.dart
@@ -84,8 +84,8 @@ class CodeField extends StatefulWidget {
   final CodeAutoComplete? autoComplete;
 
   const CodeField({
-    this.fieldKey,
     required this.controller,
+    this.fieldKey,
     this.minLines,
     this.maxLines,
     this.expands = false,

--- a/lib/src/code_field/code_field.dart
+++ b/lib/src/code_field/code_field.dart
@@ -17,7 +17,7 @@ class CodeField extends StatefulWidget {
   /// {@macro flutter.widgets.textField.smartQuotesType}
   final SmartQuotesType? smartQuotesType;
 
-/// {@macro flutter.widgets.textField.smartDashesType}
+  /// {@macro flutter.widgets.textField.smartDashesType}
   final SmartDashesType? smartDashesType;
 
   /// {@macro flutter.widgets.textField.keyboardType}
@@ -324,7 +324,8 @@ class _CodeFieldState extends State<CodeField> {
       );
     }
 
-    final codeField = TextField(key: widget.fieldKey,
+    final codeField = TextField(
+      key: widget.fieldKey,
       keyboardType: widget.keyboardType,
       smartQuotesType: widget.smartQuotesType,
       smartDashesType: widget.smartDashesType,

--- a/lib/src/code_field/code_field.dart
+++ b/lib/src/code_field/code_field.dart
@@ -401,27 +401,6 @@ class _CodeFieldState extends State<CodeField> {
       ),
       child: LayoutBuilder(
         builder: (context, constraints) {
-          // Save the textStyle and available width so _onTextChanged can
-          // accurately compute the amount of visual lines when wrapping.
-          _currentTextStyle = textStyle;
-          // Subtract left padding that will be applied inside the
-          // SingleChildScrollView when horizontal scrolling is disabled.
-          var availableWidth = constraints.maxWidth;
-          if (widget.lineNumbers) {
-            availableWidth -= widget.lineNumberStyle.width;
-          }
-
-          if ((availableWidth - _codeColumnWidth).abs() > 0.5) {
-            _codeColumnWidth = max(0, availableWidth);
-            // Recalculate the line numbers because wrapping may have
-            // changed due to a width change.
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-              if (mounted) {
-                _onTextChanged();
-              }
-            });
-          }
-
           // Control horizontal scrolling
           return widget.wrap
               ? codeField
@@ -438,7 +417,34 @@ class _CodeFieldState extends State<CodeField> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           if (widget.lineNumbers && numberCol != null) numberCol,
-          Expanded(child: codeCol),
+          Expanded(
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                // Save the textStyle and available width so _onTextChanged can
+                // accurately compute the amount of visual lines when wrapping.
+                _currentTextStyle = textStyle;
+                // Subtract left padding that will be applied inside the
+                // SingleChildScrollView when horizontal scrolling is disabled.
+                var availableWidth = constraints.maxWidth;
+
+                const caretMargin = 3.0; // 1 gap + 2 cursor
+                availableWidth -= caretMargin;
+
+                if ((availableWidth - _codeColumnWidth).abs() > 0.5) {
+                  _codeColumnWidth = max(0, availableWidth);
+                  print('availableWidth: $availableWidth');
+                  // Recalculate the line numbers because wrapping may have
+                  // changed due to a width change.
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    if (mounted) {
+                      _onTextChanged();
+                    }
+                  });
+                }
+                return codeCol;
+              },
+            ),
+          ),
         ],
       ),
     );

--- a/lib/src/code_field/code_field.dart
+++ b/lib/src/code_field/code_field.dart
@@ -84,6 +84,7 @@ class CodeField extends StatefulWidget {
   final CodeAutoComplete? autoComplete;
 
   const CodeField({
+    Key? key,
     required this.controller,
     this.fieldKey,
     this.minLines,
@@ -115,7 +116,7 @@ class CodeField extends StatefulWidget {
     this.autoComplete,
     this.textInputAction,
     this.enableSuggestions = false,
-  });
+  }) : super(key: key);
 
   @override
   State<CodeField> createState() => _CodeFieldState();

--- a/lib/src/line_numbers/line_number_controller.dart
+++ b/lib/src/line_numbers/line_number_controller.dart
@@ -18,14 +18,19 @@ class LineNumberController extends TextEditingController {
 
     for (int k = 0; k < list.length; k++) {
       final el = list[k];
-      final number = int.parse(el);
-      var textSpan = TextSpan(text: el, style: style);
-
-      if (lineNumberBuilder != null) {
-        textSpan = lineNumberBuilder!(number, style);
+      // Blank lines are placeholders inserted to align with wrapped
+      // visual lines. They should render as empty text spans to
+      // preserve vertical spacing.
+      if (el.trim().isEmpty) {
+        children.add(TextSpan(text: '', style: style));
+      } else {
+        final number = int.tryParse(el) ?? 0;
+        var textSpan = TextSpan(text: el, style: style);
+        if (lineNumberBuilder != null && number != 0) {
+          textSpan = lineNumberBuilder!(number, style);
+        }
+        children.add(textSpan);
       }
-
-      children.add(textSpan);
       if (k < list.length - 1) {
         children.add(const TextSpan(text: '\n'));
       }


### PR DESCRIPTION
This pull request fixes [this issue](https://github.com/BertrandBev/code_field/issues/6) 

![](https://user-images.githubusercontent.com/965695/120885470-0b8f6000-c624-11eb-9099-ddfb256a9f21.jpg)

Not sure about the performance, it's fast enough for my use case.

Otherwise it also 
- fixes deprecation warnings, 
- whitespaces and
- adds a field key which allows to set the key for the text field